### PR TITLE
Revalidate script: smaller batches

### DIFF
--- a/scripts/revalidate.js
+++ b/scripts/revalidate.js
@@ -7,7 +7,7 @@ let start = 0
 const revalidatePages = async (secret, baseUrl = 'https://old-norwegian-dictionary.vercel.app/') => {
   try {
     while (start < WORDS) {
-      const end = start + 500
+      const end = start + 250
       const url = `${baseUrl}/api/revalidate?secret=${secret}&start=${start}&end=${end}`
       console.time(`${start} - ${end}`)
       // eslint-disable-next-line no-await-in-loop


### PR DESCRIPTION
Currently on free plan, which gives 10s execution time per function. Use smaller batch size to either:

- Make execution short enough to pass in 10s
- Or if it wont pass, at least we'll lose fewer revalidation pages in the process.

With this patch size many batches go in 1-3 seconds, which is more than fast enough. However, some edge cases still timeout.